### PR TITLE
Uses of sed now portable. Gawk now responsible for special chars

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -155,10 +155,10 @@ opstr-riscv.h: decode-riscv.h Makefile
 	./mkopstr-riscv $(GAWK) > opstr-riscv.h
 
 decode-hitachi-sh.h: latencies-hitachi-sh.h Makefile
-	./mkdecode-hitachi-sh $(GNUSED) > decode-hitachi-sh.h
+	./mkdecode-hitachi-sh $(GAWK) > decode-hitachi-sh.h
 
 decode-riscv.h: latencies-riscv.h Makefile
-	./mkdecode-riscv $(GNUSED) > decode-riscv.h
+	./mkdecode-riscv $(GAWK) > decode-riscv.h
 
 #	Either of the lex-* would suffice for generating the LaTeX / help command array.
 help.h: lex-hitachi-sh.c Makefile

--- a/sim/decode-riscv.h
+++ b/sim/decode-riscv.h
@@ -117,4 +117,5 @@ enum
 	RV32UN_OP_UNPART1,
 
 	RV32UN_OP_UNMAX,
+
 };

--- a/sim/latencies-riscv.h
+++ b/sim/latencies-riscv.h
@@ -39,6 +39,7 @@
 /*	decode-riscv.h and opstr-riscv.h are dependent on this file	*/
 int riscv_instr_latencies[][5] =\
 {
+// --->| The tab here is important for easy sed portability
 	[RISCV_OP_LUI]		{1,	1,	1,	1,	1},//WB stage is always 1 cycle
 	[RISCV_OP_AUIPC]	{1,	1,	1,	1,	1},
 	[RISCV_OP_JAL]		{1,	1,	1,	1,	1},

--- a/sim/latencies-riscv.h
+++ b/sim/latencies-riscv.h
@@ -39,7 +39,6 @@
 /*	decode-riscv.h and opstr-riscv.h are dependent on this file	*/
 int riscv_instr_latencies[][5] =\
 {
-// --->| The tab here is important for easy sed portability
 	[RISCV_OP_LUI]		{1,	1,	1,	1,	1},//WB stage is always 1 cycle
 	[RISCV_OP_AUIPC]	{1,	1,	1,	1,	1},
 	[RISCV_OP_JAL]		{1,	1,	1,	1,	1},

--- a/sim/mkdecode-hitachi-sh
+++ b/sim/mkdecode-hitachi-sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 	if [ $# -ne 1 ]; then
-		echo 1>&2 Usage: $0 '<path to a gnu sed>'
+		echo 1>&2 Usage: $0 '<path to a Gnu awk>'
 		exit 127
 	fi
 
@@ -9,5 +9,5 @@
 	echo '/*	This is dependent on latencies-hitachi-sh.h	*/'
 	echo 'enum'
 	echo '{'
-	cat latencies-hitachi-sh.h | grep _OP_ | $1 "s/.*\[\(SUPERH_OP_.*[A-Z0-9]\)\].*/\t\1,/" | $1 "s/^\(.*MAX,\)/\n\1\n/"
+	cat latencies-hitachi-sh.h | grep _OP_ | sed "s/\(.\).*\[\(SUPERH_OP_.*[A-Z0-9]\)\].*/\1\2,/" | sed "s/^\(.*MAX,\)/MAX~\1/" | $1 -F'~' '{if($1=="MAX"){print "\n"$2"\n"}else{print $1}}'
 	echo '};'

--- a/sim/mkdecode-hitachi-sh
+++ b/sim/mkdecode-hitachi-sh
@@ -9,5 +9,5 @@
 	echo '/*	This is dependent on latencies-hitachi-sh.h	*/'
 	echo 'enum'
 	echo '{'
-	cat latencies-hitachi-sh.h | grep _OP_ | sed "s/\(.\).*\[\(SUPERH_OP_.*[A-Z0-9]\)\].*/\1\2,/" | sed "s/^\(.*MAX,\)/MAX~\1/" | $1 -F'~' '{if($1=="MAX"){print "\n"$2"\n"}else{print $1}}'
+	cat latencies-hitachi-sh.h | grep _OP_ | sed "s/.*\[\(SUPERH_OP_.*[A-Z0-9]\)\].*/\1,/" | sed "s/^\(.*MAX,\)/MAX~\1/" | $1 -F'~' '{if($1=="MAX"){print "\n\t"$2"\n"}else{print "\t"$1}}'
 	echo '};'

--- a/sim/mkdecode-riscv
+++ b/sim/mkdecode-riscv
@@ -9,5 +9,5 @@
 	echo '/*	This is dependent on latencies-riscv.h	*/'
 	echo 'enum'
 	echo '{'
-	cat latencies-riscv.h | grep _OP_ | sed "s/\(.\).*\[\(R.*_OP_.*[A-Z0-9]\)\].*/\1\2,/" | sed "s/^\(.*MAX,\)/MAX~\1/" | $1 -F'~' '{if($1=="MAX"){print "\n"$2"\n"}else{print $1}}'
+	cat latencies-riscv.h | grep _OP_ | sed "s/.*\[\(R.*_OP_.*[A-Z0-9]\)\].*/\1,/" | sed "s/^\(.*MAX,\)/MAX~\1/" | $1 -F'~' '{if($1=="MAX"){print "\n\t"$2"\n"}else{print "\t"$1}}'
 	echo '};'

--- a/sim/mkdecode-riscv
+++ b/sim/mkdecode-riscv
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 	if [ $# -ne 1 ]; then
-		echo 1>&2 Usage: $0 '<path to a gnu sed>'
+		echo 1>&2 Usage: $0 '<path to a Gnu awk>'
 		exit 127
 	fi
 
@@ -9,5 +9,5 @@
 	echo '/*	This is dependent on latencies-riscv.h	*/'
 	echo 'enum'
 	echo '{'
-	cat latencies-riscv.h | grep _OP_ | $1 "s/.*\[\(R.*_OP_.*[A-Z0-9]\)\].*/\t\1,/" | $1 "s/^\(.*MAX,\)/\n\1\n/"
+	cat latencies-riscv.h | grep _OP_ | sed "s/\(.\).*\[\(R.*_OP_.*[A-Z0-9]\)\].*/\1\2,/" | sed "s/^\(.*MAX,\)/MAX~\1/" | $1 -F'~' '{if($1=="MAX"){print "\n"$2"\n"}else{print $1}}'
 	echo '};'


### PR DESCRIPTION
All the portability problems (newline and tab characters) have been moved to gawk. As existing gawk commands used `\t`, I assume it is fine to have gawk use `\n` too.