### PR TITLE
Fix for issue #174 where sbench benchmarks fail to compile

### DIFF
--- a/benchmarks/source/superh/port/devexcp.c
+++ b/benchmarks/source/superh/port/devexcp.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "sf-types.h"
 #include "sh7708.h"
 

--- a/benchmarks/source/superh/port/devloc.c
+++ b/benchmarks/source/superh/port/devloc.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "sf-types.h"
 #include "tag.h"
 #include "devsim7708.h"

--- a/benchmarks/source/superh/sbench/Sift-MAC/sift-mac.c
+++ b/benchmarks/source/superh/sbench/Sift-MAC/sift-mac.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>

--- a/sim/sf-types.h
+++ b/sim/sf-types.h
@@ -34,7 +34,6 @@
 	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 	POSSIBILITY OF SUCH DAMAGE.
 */
-#include <stdint.h>
 #define nil	((void*)0)
 #define USED(x)
 #define uchar	uint8_t

--- a/sim/sf-types.h
+++ b/sim/sf-types.h
@@ -34,7 +34,7 @@
 	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 	POSSIBILITY OF SUCH DAMAGE.
 */
-
+#include <stdint.h>
 #define nil	((void*)0)
 #define USED(x)
 #define uchar	uint8_t

--- a/sim/sf-types.h
+++ b/sim/sf-types.h
@@ -34,6 +34,7 @@
 	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 	POSSIBILITY OF SUCH DAMAGE.
 */
+
 #define nil	((void*)0)
 #define USED(x)
 #define uchar	uint8_t


### PR DESCRIPTION
Types like ```uint32_t ```are defined by ```#include <stdint.h>``` and therefore we must include it. 

The memory issue is specific to CPU1, there is no known general fix other that using sudo at this time.